### PR TITLE
Gitpod and AWS credentials, billing & budget alarms and scrubbing secrets 2

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,13 @@
+tasks:
+  - name: aws-cli
+    env:
+      AWS_CLI_AUTO_PROMPT: on-partial
+    init: |
+      cd /workspace
+      curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      unzip awscliv2.zip
+      sudo ./aws/install
+      cd $THEIA_WORKSPACE_ROOT
 
 vscode:
   extensions:

--- a/aws/json/alarm_config.json
+++ b/aws/json/alarm_config.json
@@ -3,7 +3,7 @@
     "AlarmDescription": "This alarm would be triggered if the daily estimated charges exceeds 1$",
     "ActionsEnabled": true,
     "AlarmActions": [
-        "arn:aws:sns:us-west-2:***REMOVED***:AWS_Project_Bootcamp_CloudWatch_Alarm"
+        "arn:aws:sns:us-west-2:013073124868:AWS_Project_Bootcamp_CloudWatch_Alarm"
     ],
     "EvaluationPeriods": 1,
     "DatapointsToAlarm": 1,

--- a/aws/json/alarm_config.json
+++ b/aws/json/alarm_config.json
@@ -1,0 +1,35 @@
+{
+    "AlarmName": "DailyEstimatedCharges",
+    "AlarmDescription": "This alarm would be triggered if the daily estimated charges exceeds 1$",
+    "ActionsEnabled": true,
+    "AlarmActions": [
+        "arn:aws:sns:us-west-2:***REMOVED***:AWS_Project_Bootcamp_CloudWatch_Alarm"
+    ],
+    "EvaluationPeriods": 1,
+    "DatapointsToAlarm": 1,
+    "Threshold": 1,
+    "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    "TreatMissingData": "breaching",
+    "Metrics": [{
+        "Id": "m1",
+        "MetricStat": {
+            "Metric": {
+                "Namespace": "AWS/Billing",
+                "MetricName": "EstimatedCharges",
+                "Dimensions": [{
+                    "Name": "Currency",
+                    "Value": "USD"
+                }]
+            },
+            "Period": 86400,
+            "Stat": "Maximum"
+        },
+        "ReturnData": false
+    },
+    {
+        "Id": "e1",
+        "Expression": "IF(RATE(m1)>0,RATE(m1)*86400,0)",
+        "Label": "DailyEstimatedCharges",
+        "ReturnData": true
+    }]
+  }

--- a/aws/json/budget-notifications-with-subscribers.json
+++ b/aws/json/budget-notifications-with-subscribers.json
@@ -1,0 +1,16 @@
+[
+    {
+        "Notification": {
+            "ComparisonOperator": "GREATER_THAN",
+            "NotificationType": "ACTUAL",
+            "Threshold": 80,
+            "ThresholdType": "PERCENTAGE"
+        },
+        "Subscribers": [
+            {
+                "Address": "***REMOVED***",
+                "SubscriptionType": "EMAIL"
+            }
+        ]
+    }
+  ]

--- a/aws/json/budget-notifications-with-subscribers.json
+++ b/aws/json/budget-notifications-with-subscribers.json
@@ -8,7 +8,7 @@
         },
         "Subscribers": [
             {
-                "Address": "***REMOVED***",
+                "Address": "alearning58@gmail.com",
                 "SubscriptionType": "EMAIL"
             }
         ]

--- a/aws/json/budget.json
+++ b/aws/json/budget.json
@@ -1,0 +1,31 @@
+{
+    "BudgetLimit": {
+        "Amount": "5",
+        "Unit": "USD"
+    },
+    "BudgetName": "My AWS Bootcamp Monthly Budget",
+    "BudgetType": "COST",
+    "CostFilters": {
+        "TagKeyValue": [
+            "user:Key$value1",
+            "user:Key$value2"
+        ]
+    },
+    "CostTypes": {
+        "IncludeCredit": true,
+        "IncludeDiscount": true,
+        "IncludeOtherSubscription": true,
+        "IncludeRecurring": true,
+        "IncludeRefund": true,
+        "IncludeSubscription": true,
+        "IncludeSupport": true,
+        "IncludeTax": true,
+        "IncludeUpfront": true,
+        "UseBlended": false
+    },
+    "TimePeriod": {
+        "Start": 1477958399,
+        "End": 3706473600
+    },
+    "TimeUnit": "MONTHLY"
+  }

--- a/aws/json/budget.json
+++ b/aws/json/budget.json
@@ -28,4 +28,5 @@
         "End": 3706473600
     },
     "TimeUnit": "MONTHLY"
+    
   }

--- a/aws/json/budget.json
+++ b/aws/json/budget.json
@@ -28,5 +28,4 @@
         "End": 3706473600
     },
     "TimeUnit": "MONTHLY"
-    
   }


### PR DESCRIPTION
This PR consists of:

- setting up `Gitpod` configurations,
- exporting and adding `ENV` variables
- creating AWS billing alarm
- creating AWS budgets
- scrubbing `github` history of every `secrets`